### PR TITLE
Upgrade to latest EDC version

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: 5191d3e6dd9ac5d78264d05ae69edb4d297b606a
+        ref: 9085e5e71e07b1e1eef05248dbff2c8d6b911e27
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.registration.manager;
 
-import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
+import org.eclipse.dataspaceconnector.common.statemachine.StateMachineManager;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.registration.authority.model.Participant;
 import org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus;
@@ -37,7 +37,7 @@ public class ParticipantManager {
     private final Monitor monitor;
     private final ParticipantStore participantStore;
     private final CredentialsVerifier credentialsVerifier;
-    private final StateMachine stateMachine;
+    private final StateMachineManager stateMachineManager;
 
     public ParticipantManager(Monitor monitor, ParticipantStore participantStore, CredentialsVerifier credentialsVerifier, ExecutorInstrumentation executorInstrumentation) {
         this.monitor = monitor;
@@ -48,7 +48,7 @@ public class ParticipantManager {
         WaitStrategy waitStrategy = () -> 5000L;
 
         // define state machine
-        stateMachine = StateMachine.Builder.newInstance("registration-service", monitor, executorInstrumentation, waitStrategy)
+        stateMachineManager = StateMachineManager.Builder.newInstance("registration-service", monitor, executorInstrumentation, waitStrategy)
                 .processor(processParticipantsInState(ONBOARDING_INITIATED, this::processOnboardingInitiated))
                 .processor(processParticipantsInState(AUTHORIZING, this::processAuthorizing))
                 .build();
@@ -58,14 +58,14 @@ public class ParticipantManager {
      * Start the participant manager state machine processor thread.
      */
     public void start() {
-        stateMachine.start();
+        stateMachineManager.start();
     }
 
     /**
      * Stop the participant manager state machine processor thread.
      */
     public void stop() {
-        stateMachine.stop();
+        stateMachineManager.stop();
     }
 
     private Boolean processOnboardingInitiated(Participant participant) {


### PR DESCRIPTION
## What this PR changes/adds

Use latest EDC version to bring latest changes.

## Why it does that

Due to an EDC class rename, registration service was incompatible to run with latest version of EDC.

## Linked Issue(s)

Related to https://github.com/agera-edc/MinimumViableDataspace/issues/56

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
