### PR TITLE
feat(build): add signing config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,9 @@ allprojects {
         maven {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
         }
+        maven{
+            url= uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     if (!project.hasProperty("skip.signing")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ val edcWebsiteUrl: String by project
 val edcScmUrl: String by project
 
 val defaultVersion: String by project
-// makes the project version overridable using the "-Pversion=..." flag. Useful for CI builds
-val projectVersion: String = (project.findProperty("version") ?: defaultVersion) as String
+// makes the project version overridable using the "-PregSrvVersion=..." flag. Useful for CI builds
+val projectVersion: String = (project.findProperty("regSrvVersion") ?: defaultVersion) as String
 
 var deployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,69 @@
 plugins {
     java
     `java-library`
+    signing
+    `maven-publish`
+    id("org.gradle.crypto.checksum") version "1.4.0"
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
-val projectVersion: String by project
 val projectGroup: String by project
 val swagger: String by project
 val rsApi: String by project
 
+// these values are required for the project POM (for publishing)
+val edcDeveloperId: String by project
+val edcDeveloperName: String by project
+val edcDeveloperEmail: String by project
+val edcScmConnection: String by project
+val edcWebsiteUrl: String by project
+val edcScmUrl: String by project
+
+val defaultVersion: String by project
+// makes the project version overridable using the "-Pversion=..." flag. Useful for CI builds
+val projectVersion: String = (project.findProperty("version") ?: defaultVersion) as String
+
+var deployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+if (projectVersion.contains("SNAPSHOT")) {
+    deployUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+subprojects{
+    afterEvaluate {
+        publishing {
+            publications.forEach { i ->
+                val mp = (i as MavenPublication)
+                mp.pom {
+                    name.set(project.name)
+                    description.set("edc :: ${project.name}")
+                    url.set(edcWebsiteUrl)
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                        developers {
+                            developer {
+                                id.set(edcDeveloperId)
+                                name.set(edcDeveloperName)
+                                email.set(edcDeveloperEmail)
+                            }
+                        }
+                        scm {
+                            connection.set(edcScmConnection)
+                            url.set(edcScmUrl)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 allprojects {
+    apply(plugin = "maven-publish")
     version = projectVersion
     group = projectGroup
 
@@ -17,6 +72,27 @@ allprojects {
         mavenLocal()
         maven {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
+        }
+    }
+
+    if (!project.hasProperty("skip.signing")) {
+        apply(plugin = "signing")
+        publishing {
+            repositories {
+                maven {
+                    name = "OSSRH"
+                    setUrl(deployUrl)
+                    credentials {
+                        username = System.getenv("OSSRH_USER") ?: return@credentials
+                        password = System.getenv("OSSRH_PASSWORD") ?: return@credentials
+                    }
+                }
+            }
+
+            signing {
+                useGpgCmd()
+                sign(publishing.publications)
+            }
         }
     }
 
@@ -55,5 +131,16 @@ allprojects {
 buildscript {
     dependencies {
         classpath("io.swagger.core.v3:swagger-gradle-plugin:2.1.13")
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+            username.set(System.getenv("OSSRH_USER") ?: return@sonatype)
+            password.set(System.getenv("OSSRH_PASSWORD") ?: return@sonatype)
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
+# defaultVersion is used when "-Pversion=...." is no supplied. Should always be equal to edcVersion!
+defaultVersion=0.0.1-SNAPSHOT
 projectGroup=org.eclipse.dataspaceconnector.registrationservice
-projectVersion=0.0.1-SNAPSHOT
+
 edcGroup=org.eclipse.dataspaceconnector
 edcVersion=0.0.1-SNAPSHOT
 assertj=3.22.0
@@ -11,4 +13,10 @@ rsApi=3.0.0
 faker=1.0.2
 swagger=2.1.13
 jacksonVersion=2.13.1
-faker=1.0.2
+# information required for publishing artifacts:
+edcDeveloperId=mspiekermann
+edcDeveloperName=Markus Spiekermann
+edcDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
+edcScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/RegistrationService.git
+edcWebsiteUrl=https://github.com/eclipse-dataspaceconnector/RegistrationService.git
+edcScmUrl=https://github.com/eclipse-dataspaceconnector/RegistrationService.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-# defaultVersion is used when "-Pversion=...." is no supplied. Should always be equal to edcVersion!
+# defaultVersion is used when "-PregSrvVersion=...." is no supplied. Should always be equal to edcVersion!
 defaultVersion=0.0.1-SNAPSHOT
 projectGroup=org.eclipse.dataspaceconnector.registrationservice
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds configuration properties and plugins necessary for publishing artifacts to MavenCentral and OSSRH Staging (when the `-SNAPSHOT` suffix is added to the version.

## Why it does that

When building connector images in MVD we need to pull in Maven dependencies from EDC core (already exists), and the RegistrationService.

## Further notes

- the `projectVersion` property was refactored to `defaultVersion` because it should/must be necessary to override the version with a flag: `-PregSrvVersion=....`
- I chose to call the version override flag `regSrvVersion` because a `version` property already exists with a default value of `unspecified`, and as far as I know kotlin ternary operators only exist for nullable expressions, not for boolean ones.
- The Jenkins job is set up to poll the `main` branch every 30 minutes for changes, and publishes a version if necessary. Once this PR is merged, it will get picked up and a version will get published.

## Linked Issue(s)

Closes #13 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
