### PR TITLE
chore: use maven artifacts instead of local builds

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -3,41 +3,9 @@ description: "Setup Gradle"
 runs:
   using: "composite"
   steps:
-    # Checkout EDC code into DataSpaceConnector directory.
-    - name: Checkout EDC
-      uses: actions/checkout@v2
-      with:
-        repository: eclipse-dataspaceconnector/DataSpaceConnector
-        path: DataSpaceConnector
-        ref: v0.0.1-milestone-5
-
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
-
-    # Cache EDC packages (installed into ~/.m2) in-between runs.
-    # If the latest EDC commit ID has not changed since the last run, this will restore
-    # its Maven packages from the cache.
-    - name: Cache EDC packages
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.m2
-        # .git/FETCH_HEAD contains latest commit ID
-        key: ${{ runner.os }}-m2-${{ hashFiles('DataSpaceConnector/.git/FETCH_HEAD') }}
-
-    # Install EDC packages into ~/.m2.
-    # This action only runs if the packages could not be restored from the cache.
-    - name: Build EDC packages
-      run: |
-        ./gradlew publishToMavenLocal -Pskip.signing
-      if: steps.cache.outputs.cache-hit != 'true' # only on cache miss
-      shell: bash
-      working-directory: DataSpaceConnector
-
-    - name: Delete EDC packages
-      run: rm -r DataSpaceConnector
-      shell: bash


### PR DESCRIPTION
## What this PR changes/adds

This PR switches from checkout out and building locally the EDC core code to simply using maven artifacts from MavenCentral.

## Why it does that

To streamline the build process.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
