### PR TITLE
Chore/ci full build

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-setup
 
-      - name: 'Build launchers'
+      - name: 'Build package'
         run: ./gradlew -DuseFsVault="true" build
 
       - name: 'Upgrade docker-compose (for --wait option)'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/gradle-setup
 
       - name: 'Build launchers'
-        run: ./gradlew -DuseFsVault="true" :launcher:shadowJar :system-tests:launchers:identity-hub:shadowJar
+        run: ./gradlew -DuseFsVault="true" build
 
       - name: 'Upgrade docker-compose (for --wait option)'
         run: |

--- a/system-tests/launchers/identity-hub/build.gradle.kts
+++ b/system-tests/launchers/identity-hub/build.gradle.kts
@@ -36,3 +36,11 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("app.jar")
 }
+
+tasks.withType<Tar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType<Zip> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}


### PR DESCRIPTION
## What this PR changes/adds

Build the full repository, not just `launcher` projects, in CI.

## Why it does that

This ensures all unit tests are run.

## Further notes

A fix was required to avoid this error:

```
160
Execution failed for task ':system-tests:launchers:identity-hub:distTar'.
[161](https://github.com/eclipse-dataspaceconnector/RegistrationService/runs/7742548603?check_suite_focus=true#step:5:162)
> Task :system-tests:launchers:identity-hub:startScripts
[167](https://github.com/eclipse-dataspaceconnector/RegistrationService/runs/7742548603?check_suite_focus=true#step:5:168)
> Task :system-tests:launchers:identity-hub:distTar FAILED
[156](https://github.com/eclipse-dataspaceconnector/RegistrationService/runs/7742548603?check_suite_focus=true#step:5:157)
> Entry identity-hub-0.0.1-SNAPSHOT/lib/identity-hub-0.0.1-SNAPSHOT.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
[157](https://github.com/eclipse-dataspaceconnector/RegistrationService/runs/7742548603?check_suite_focus=true#step:5:158)
```


_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
