### PR TITLE
Test reports and code coverage

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,6 +2,8 @@ name: Test Code (Style, Tests)
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - '**.md'
@@ -22,6 +24,9 @@ jobs:
         run: git diff --exit-code
 
   Test:
+    permissions:
+      checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +50,7 @@ jobs:
         timeout-minutes: 10
         env:
           INTEGRATION_TEST: true
+          JACOCO: "true"
 
       - name: 'Publish Test Results'
         uses: EnricoMi/publish-unit-test-result-action@v1
@@ -55,6 +61,9 @@ jobs:
       - name: 'docker-compose logs'
         run: docker-compose logs
         if: always()
+
+      - name: CodeCov
+        uses: codecov/codecov-action@v3
 
   Checkstyle:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `maven-publish`
     id("org.gradle.crypto.checksum") version "1.4.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    jacoco
 }
 
 val projectGroup: String by project
@@ -63,6 +64,7 @@ subprojects{
 }
 
 allprojects {
+    apply(plugin = "java")
     apply(plugin = "maven-publish")
     version = projectVersion
     group = projectGroup
@@ -124,10 +126,23 @@ allprojects {
         }
     }
 
-    tasks.withType<Test> {
+    tasks.test {
         useJUnitPlatform()
         testLogging {
             showStandardStreams = true
+        }
+    }
+
+    if (System.getenv("JACOCO") == "true") {
+        apply(plugin = "jacoco")
+        tasks.test {
+            finalizedBy(tasks.jacocoTestReport)
+        }
+        tasks.jacocoTestReport {
+            reports {
+                // Generate XML report for codecov.io
+                xml.required.set(true)
+            }
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

- Use jacoco plugin for test coverage.
- Upload test coverage data to CodeCov.
- Restrict push trigger to main branch only. To avoid duplicate workflow runs on PRs

Codecov report https://codecov.io/github/agera-edc/RegistrationService/commit/863403fc5f6c30cb771ff1c5530ca9767b1e8ede

These are implemented exactly like in EDC and MVD (https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/pull/52)

## Why it does that

Improved reporting, aligned with EDC practices.

## Linked Issue(s)

Relates to https://github.com/agera-edc/MinimumViableDataspace/issues/251

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
