### PR TITLE
Added checkstyle and codeql.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/gradle-setup
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      # Compiles production Java source (without tests)
+      - name: Build
+        run: ./gradlew compileJava --no-daemon
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -4,12 +4,27 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
   pull_request:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
 
 jobs:
+  Checkstyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/gradle-setup
+
+      - name: Run Checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
 
   OpenAPI-Definitions:
     runs-on: ubuntu-latest
@@ -64,22 +79,3 @@ jobs:
 
       - name: CodeCov
         uses: codecov/codecov-action@v3
-
-  Checkstyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
-      - name: Run Checkstyle
-        if: github.event_name == 'pull_request'
-        uses: nikitasavinov/checkstyle-action@0.6.0
-        with:
-          checkstyle_config: resources/checkstyle-config.xml
-          level: error
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tool_name: 'checkstyle'
-          checkstyle_version: '9.0'
-          reporter: 'github-pr-check'
-          # Include only violations on added or modified files
-          filter_mode: 'file'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     signing
     `maven-publish`
+    checkstyle
     id("org.gradle.crypto.checksum") version "1.4.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     jacoco
@@ -66,6 +67,7 @@ subprojects{
 allprojects {
     apply(plugin = "java")
     apply(plugin = "maven-publish")
+    apply(plugin = "checkstyle")
     version = projectVersion
     group = projectGroup
 
@@ -78,6 +80,16 @@ allprojects {
         maven{
             url= uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
+    }
+
+    // Specify config file excluding generated source files
+    System.setProperty("org.checkstyle.google.suppressionfilter.config", file("${rootProject.projectDir.path}/resources/checkstyle-suppressions.xml").absolutePath)
+
+    checkstyle {
+        toolVersion = "9.0"
+        configFile = rootProject.file("resources/checkstyle-config.xml")
+        configDirectory.set(rootProject.file("resources"))
+        maxErrors = 0 // does not tolerate errors
     }
 
     if (!project.hasProperty("skip.signing")) {

--- a/docs/developer/2022-08-15-code-quality-tooling/README.md
+++ b/docs/developer/2022-08-15-code-quality-tooling/README.md
@@ -1,0 +1,13 @@
+# Code Quality
+
+## Decision
+
+Use [Checkstyle](https://checkstyle.sourceforge.io/) and [CodeQL](https://codeql.github.com/) static code analysis tools to guarantee adherence to coding standards and discover potential vulnerabilities.
+
+## Rationale
+
+Both Checkstyle and CodeQL are already in use in the EDC framework, so these tools are the natural choice in related projects like the Registration service as well.
+
+## Approach
+
+Checkstyle checks and CodeQL analysis need to run on Pull Requests in both upstream and forked repositories.

--- a/resources/checkstyle-config.xml
+++ b/resources/checkstyle-config.xml
@@ -108,7 +108,7 @@
                     COMPACT_CTOR_DEF"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
-      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
       <property name="id" value="RightCurlyAlone"/>
       <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                      or preceding-sibling::*[last()][self::LCURLY]]"/>


### PR DESCRIPTION
## What this PR changes/adds

Added checkstyle and codeql in workflows.
Example of failing workflow: https://github.com/agera-edc/RegistrationService/runs/7840323571?check_suite_focus=true

## Why it does that

To detect checkstyle errors + have codeql running when creating PRs.

## Further notes

Same PR as in IdentityHub, the difference is that the path to the suppress file is setup in order to ignore generated resources.

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/253

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
