### PR TITLE
Configure connect and read timeout for rest client

### DIFF
--- a/rest-client/build.gradle.kts
+++ b/rest-client/build.gradle.kts
@@ -68,6 +68,7 @@ val faker: String by project
 
 dependencies {
     api("${edcGroup}:identity-did-crypto:${edcVersion}")
+    api("${edcGroup}:common-util:${edcVersion}")
 
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("com.github.javafaker:javafaker:${faker}")

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -22,13 +22,15 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Duration;
 import java.util.function.Function;
 
+import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
+
 /**
  * Factory class for {@link ApiClient}.
  */
 public class ApiClientFactory {
 
-    private static final int API_CLIENT_CONNECT_TIMEOUT = Integer.parseInt(getEnv("API_CLIENT_CONNECT_TIMEOUT", "30"));
-    private static final int API_CLIENT_READ_TIMEOUT = Integer.parseInt(getEnv("API_CLIENT_READ_TIMEOUT", "60"));
+    private static final int API_CLIENT_CONNECT_TIMEOUT = Integer.parseInt(propOrEnv("API_CLIENT_CONNECT_TIMEOUT", "30"));
+    private static final int API_CLIENT_READ_TIMEOUT = Integer.parseInt(propOrEnv("API_CLIENT_READ_TIMEOUT", "60"));
 
     private ApiClientFactory() {
     }
@@ -56,11 +58,4 @@ public class ApiClientFactory {
         return apiClient;
     }
 
-    private static String getEnv(String key, String defaultValue) {
-        String value = System.getenv(key);
-        if (value == null) {
-            return defaultValue;
-        }
-        return value;
-    }
 }

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -63,5 +63,4 @@ public class ApiClientFactory {
         apiClient.setRequestInterceptor(new JsonWebSignatureHeaderInterceptor(credentialsProvider, baseUri));
         return apiClient;
     }
-
 }

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -30,9 +30,9 @@ import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationF
  */
 public class ApiClientFactory {
 
-    @EdcSetting
+    @EdcSetting(type = "integer", value = "Rest api client connect timeout")
     private static final String API_CLIENT_CONNECT_TIMEOUT = "api.client.connect.timeout";
-    @EdcSetting
+    @EdcSetting(type = "integer", value = "Rest api client read timeout")
     private static final String API_CLIENT_READ_TIMEOUT = "api.client.read.timeout";
 
     private ApiClientFactory() {

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -41,7 +41,7 @@ public class ApiClientFactory {
     /**
      * Create a new instance of {@link ApiClient} configured to access the given URL.
      * <p>
-     * Configured with connectTimeout(default to 30 seconds) and readTimeout(default to 60 seconds).
+     * Configured with connectTimeout (default is 30 seconds) and readTimeout (default is 60 seconds).
      * Note that the type of {@code credentialsProvider} is modeled on the EDC {@code IdentityService} interface, for easier integration.
      *
      * @param baseUri             API base URL.


### PR DESCRIPTION
## What this PR changes/adds

Configure connect and read timeout for rest client. readTimeout is 60 seconds and connectTimeout is 30 seconds.

## Why it does that

It was observed that client calls didn't timeout which mean CI steps can be running until it reaches CI timeout limit. Which can be very high e.g. 1 hour. For example, see CI run here https://github.com/agera-edc/MinimumViableDataspace/runs/7874926981?check_suite_focus=true  which kept on running until cancelled manually.

## Linked Issue(s)

Relates to https://github.com/agera-edc/MinimumViableDataspace/issues/46

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
