### PR TITLE
Collect observability data

### DIFF
--- a/extensions/dataspace-authority-spi/src/main/java/org/eclipse/dataspaceconnector/registration/authority/model/Participant.java
+++ b/extensions/dataspace-authority-spi/src/main/java/org/eclipse/dataspaceconnector/registration/authority/model/Participant.java
@@ -16,11 +16,14 @@ package org.eclipse.dataspaceconnector.registration.authority.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.String.format;
+import static java.util.Collections.unmodifiableMap;
 import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.AUTHORIZED;
 import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.AUTHORIZING;
 import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.DENIED;
@@ -32,10 +35,11 @@ import static org.eclipse.dataspaceconnector.registration.authority.model.Partic
  * Dataspace participant.
  */
 @JsonDeserialize(builder = Participant.Builder.class)
-public class Participant {
+public class Participant implements TraceCarrier {
 
     private String did;
     private ParticipantStatus status = ONBOARDING_INITIATED;
+    private Map<String, String> traceContext = Map.of();
 
     private Participant() {
     }
@@ -46,6 +50,11 @@ public class Participant {
 
     public ParticipantStatus getStatus() {
         return status;
+    }
+
+    @Override
+    public Map<String, String> getTraceContext() {
+        return traceContext;
     }
 
     public void transitionAuthorizing() {
@@ -100,6 +109,11 @@ public class Participant {
 
         public Builder status(ParticipantStatus status) {
             participant.status = status;
+            return this;
+        }
+
+        public Builder traceContext(Map<String, String> traceContext) {
+            participant.traceContext = unmodifiableMap(traceContext);
             return this;
         }
 

--- a/extensions/registration-service/build.gradle.kts
+++ b/extensions/registration-service/build.gradle.kts
@@ -12,6 +12,7 @@ val jupiterVersion: String by project
 val assertj: String by project
 val mockitoVersion: String by project
 val faker: String by project
+val openTelemetryVersion: String by project
 
 dependencies {
     implementation("${edcGroup}:http:${edcVersion}")
@@ -19,6 +20,7 @@ dependencies {
     implementation("${edcGroup}:identity-did-crypto:${edcVersion}")
     implementation("${identityHubGroup}:identity-hub-client:${identityHubVersion}")
     implementation("${edcGroup}:api-core:${edcVersion}")
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     implementation(project(":extensions:participant-store-spi"))
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/AuthorityExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/AuthorityExtension.java
@@ -44,6 +44,7 @@ import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 
 import java.util.Objects;
 
@@ -93,6 +94,9 @@ public class AuthorityExtension implements ServiceExtension {
     @Inject
     private DtoTransformerRegistry transformerRegistry;
 
+    @Inject
+    private Telemetry telemetry;
+
     private ParticipantManager participantManager;
 
     @Override
@@ -103,10 +107,10 @@ public class AuthorityExtension implements ServiceExtension {
         var authenticationService = new DidJwtAuthenticationFilter(monitor, didPublicKeyResolver, audience);
         var verifiableCredentialService = verifiableCredentialService(context);
 
-        participantManager = new ParticipantManager(monitor, participantStore, participantVerifier, executorInstrumentation, verifiableCredentialService);
+        participantManager = new ParticipantManager(monitor, participantStore, participantVerifier, executorInstrumentation, verifiableCredentialService, telemetry);
         transformerRegistry.register(new ParticipantToParticipantDtoTransformer());
 
-        var registrationService = new RegistrationService(monitor, participantStore, transformerRegistry);
+        var registrationService = new RegistrationService(monitor, participantStore, transformerRegistry, telemetry);
         webService.registerResource(CONTEXT_ALIAS, new RegistrationApiController(registrationService));
 
         webService.registerResource(CONTEXT_ALIAS, authenticationService);

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,11 +38,13 @@ public class RegistrationService {
     private final Monitor monitor;
     private final ParticipantStore participantStore;
     private final DtoTransformerRegistry transformerRegistry;
+    private final Telemetry telemetry;
 
-    public RegistrationService(Monitor monitor, ParticipantStore participantStore, DtoTransformerRegistry transformerRegistry) {
+    public RegistrationService(Monitor monitor, ParticipantStore participantStore, DtoTransformerRegistry transformerRegistry, Telemetry telemetry) {
         this.monitor = monitor;
         this.participantStore = participantStore;
         this.transformerRegistry = transformerRegistry;
+        this.telemetry = telemetry;
     }
 
     /**
@@ -90,6 +93,7 @@ public class RegistrationService {
         var participant = Participant.Builder.newInstance()
                 .did(did)
                 .status(ONBOARDING_INITIATED)
+                .traceContext(telemetry.getCurrentTraceContext())
                 .build();
 
         participantStore.save(participant);

--- a/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManagerTest.java
+++ b/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManagerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -53,7 +54,7 @@ class ParticipantManagerTest {
     ParticipantStore participantStore = mock(ParticipantStore.class);
     ParticipantVerifier participantVerifier = mock(ParticipantVerifier.class);
     VerifiableCredentialService verifiableCredentialService = mock(VerifiableCredentialService.class);
-    ParticipantManager service = new ParticipantManager(monitor, participantStore, participantVerifier, ExecutorInstrumentation.noop(), verifiableCredentialService);
+    ParticipantManager service = new ParticipantManager(monitor, participantStore, participantVerifier, ExecutorInstrumentation.noop(), verifiableCredentialService, new Telemetry());
     Participant.Builder participantBuilder = createParticipant();
     ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ swagger=2.1.13
 jacksonVersion=2.13.1
 httpMockServer=5.12.0
 jetBrainsAnnotationsVersion=15.0
+openTelemetryVersion=1.12.0
 
 # information required for publishing artifacts:
 edcDeveloperId=mspiekermann

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:17-slim-buster
 
 # Optional JVM arguments, such as memory settings
 ARG JVM_ARGS=""
+ARG APPINSIGHTS_AGENT_VERSION=3.2.11
 
 # Install curl, then delete apt indexes to save image space
 RUN apt update \
@@ -10,7 +11,11 @@ RUN apt update \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 WORKDIR /app
+
+RUN curl --fail -LO https://github.com/microsoft/ApplicationInsights-Java/releases/download/$APPINSIGHTS_AGENT_VERSION/applicationinsights-agent-$APPINSIGHTS_AGENT_VERSION.jar
+
 COPY ./build/libs/app.jar /app
+COPY ./logging.properties /app
 
 EXPOSE 8182
 
@@ -23,5 +28,6 @@ ENV WEB_HTTP_PATH="/api"
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable
 ENV ENV_JVM_ARGS=$JVM_ARGS
+ENV ENV_APPINSIGHTS_AGENT_VERSION=$APPINSIGHTS_AGENT_VERSION
 ENTRYPOINT [ "sh", "-c", \
-    "exec java ${ENV_JVM_ARGS} -jar app.jar"]
+    "exec java -javaagent:applicationinsights-agent-$ENV_APPINSIGHTS_AGENT_VERSION.jar $ENV_JVM_ARGS -Djava.util.logging.config.file=/app/logging.properties -jar app.jar"]

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -31,8 +31,14 @@ dependencies {
     implementation("${edcGroup}:identity-did-core:${edcVersion}")
     implementation("${edcGroup}:core:${edcVersion}")
     implementation("${edcGroup}:observability-api:${edcVersion}")
+    implementation("${edcGroup}:core-micrometer:${edcVersion}")
+    runtimeOnly("${edcGroup}:jetty-micrometer:${edcVersion}")
+    runtimeOnly("${edcGroup}:jersey-micrometer:${edcVersion}")
     implementation("${edcGroup}:filesystem-configuration:${edcVersion}")
     implementation("${identityHubGroup}:identity-hub-credentials-verifier:${identityHubVersion}")
+
+    // JDK Logger
+    implementation("${edcGroup}:jdk-logger-monitor:${edcVersion}")
 
     // To use FileSystem vault e.g. -DuseFsVault="true".Only for non-production usages.
     val useFsVault: Boolean = System.getProperty("useFsVault", "false").toBoolean()

--- a/launcher/logging.properties
+++ b/launcher/logging.properties
@@ -1,0 +1,7 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n
+org.eclipse.dataspaceconnector.level = FINE
+org.eclipse.dataspaceconnector.handler = java.util.logging.ConsoleHandler


### PR DESCRIPTION
## What this PR changes/adds

This PR enables tracing observability data: logs, metrics, traces. It adds the application insights java agent to the Dockerfile.

Logs:
- Add JDK Monitor Logger extension
- Add logging configuration file

Metrics:
- Add extension for enabling jetty, jersey and default metrics 

Traces:
- Trace context propagation for state machine operations
- Add @WithSpan annotation to methods where the Participant changes the onboarding status.

Traces in Application Insights from local Registration Service set up:
![Screenshot 2022-08-15 at 14 49 51](https://user-images.githubusercontent.com/4217554/185343818-e9aaf700-c059-49be-a59f-e36f7f5ddb42.png)


## Why it does that

We want to be able to monitor the application.

## Further notes

In the future we can clean up the Dockerfile and remove the application insights java agent jar from there. Instead we can create custom launcher for Registration Service in MVD to extend the Dockerfile adding the app insights java agent jar. 

Linked to PR in MVD: https://github.com/agera-edc/MinimumViableDataspace/pull/261

## Linked Issue(s)

Linked to [#247](https://github.com/agera-edc/MinimumViableDataspace/issues/247)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
