### PR TITLE
fix: Add missing `publishing` task for all extensions

### DIFF
--- a/extensions/dataspace-authority-spi/build.gradle.kts
+++ b/extensions/dataspace-authority-spi/build.gradle.kts
@@ -24,3 +24,11 @@ dependencies {
     testFixturesImplementation("com.github.javafaker:javafaker:${faker}")
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("dataspace-authority-spi") {
+            artifactId = "dataspace-authority-spi"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/participant-store-spi/build.gradle.kts
+++ b/extensions/participant-store-spi/build.gradle.kts
@@ -12,3 +12,11 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("participant-store-spi") {
+            artifactId = "participant-store-spi"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/participant-verifier/build.gradle.kts
+++ b/extensions/participant-verifier/build.gradle.kts
@@ -25,3 +25,11 @@ dependencies {
     testImplementation("com.github.javafaker:javafaker:${faker}")
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("participant-verifier") {
+            artifactId = "participant-verifier"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/registration-policy-gaiax-member/build.gradle.kts
+++ b/extensions/registration-policy-gaiax-member/build.gradle.kts
@@ -22,3 +22,11 @@ dependencies {
     testImplementation("com.github.javafaker:javafaker:${faker}")
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("registration-policy-gaiax-member") {
+            artifactId = "registration-policy-gaiax-member"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/registration-service/build.gradle.kts
+++ b/extensions/registration-service/build.gradle.kts
@@ -35,3 +35,12 @@ dependencies {
     testImplementation(testFixtures(project(":rest-client")))
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("registration-service") {
+            artifactId = "registration-service"
+            from(components["java"])
+        }
+    }
+}
+


### PR DESCRIPTION
## What this PR changes/adds

Add missing `publishing` task for all extensions.

## Why it does that

Each extension must publish an artifact. 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
