### PR TITLE
refactor(SqlParticipantStore): apply AbstractSqlStore class and PostgresqlStoreSetupExtension in test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 defaultVersion=0.0.1-SNAPSHOT
 projectGroup=org.eclipse.dataspaceconnector.registrationservice
 edcGroup=org.eclipse.dataspaceconnector
-edcVersion=0.0.1-20221021-SNAPSHOT
+edcVersion=0.0.1-20221027-SNAPSHOT
 identityHubGroup=org.eclipse.dataspaceconnector.identityhub
 identityHubVersion=0.0.1-20221001-SNAPSHOT
 okHttpVersion=4.10.0
@@ -21,7 +21,6 @@ openTelemetryVersion=1.12.0
 postgresVersion=42.4.0
 failsafeVersion=3.2.4
 cosmosSdkVersion=4.37.0
-
 # information required for publishing artifacts:
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann


### PR DESCRIPTION
## What this PR changes/adds

Make the `SqlParticipantStore` extends `AbstractSqlStore` and make usage of the `PostgresqlStoreSetupExtension` for 
the test setup

## Why it does that

Reduce duplicated code when in the SQL store implementation and testing.

## Linked Issue(s)

Closes #49 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
