### PR TITLE
chore: use standard version property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,10 @@ val edcScmUrl: String by project
 
 val defaultVersion: String by project
 // makes the project version overridable using the "-PregSrvVersion=..." flag. Useful for CI builds
-val actualVersion: String = (project.findProperty("regSrvVersion") ?: defaultVersion) as String
-
+var actualVersion: String = (project.findProperty("version") ?: defaultVersion) as String
+if (actualVersion == "unspecified") {
+    actualVersion = defaultVersion
+}
 
 allprojects {
 


### PR DESCRIPTION
## What this PR changes/adds

Moves toward using the standard Gradle `version` property, instead of the currently used `regSrvVersion` property.


## Why it does that

Consistency with Gradle conventions.

## Further notes

The build jobs on Jenkins, that accept a version parameter, must be adopted after this PR is merged.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
